### PR TITLE
Changing to be more compatible with pdf.js color spaces.

### DIFF
--- a/jpg.js
+++ b/jpg.js
@@ -602,7 +602,7 @@ var JpegImage = (function jpegImage() {
         }
       }
     },
-    getData: function getData(data, width, height) {
+    getData: function getData(width, height) {
       function clampTo8bit(a) {
         return a < 0 ? 0 : a > 255 ? 255 : a;
       }
@@ -614,6 +614,8 @@ var JpegImage = (function jpegImage() {
       var offset = 0;
       var Y, Cb, Cr, K, C, M, Ye, R, G, B;
       var colorTransform;
+      var dataLength = width * height * this.components.length;
+      var data = new Uint8Array(dataLength);
       switch (this.components.length) {
         case 1:
           component1 = this.components[0];
@@ -709,6 +711,7 @@ var JpegImage = (function jpegImage() {
         default:
           throw 'Unsupported color mode';
       }
+      return data;
     },
     copyToImageData: function copyToImageData(imageData) {
       this.getData(imageData.data, imageData.width, imageData.height);


### PR DESCRIPTION
-Changes it so the color's don't get converted to RGB so we can use the color space management in pdf.js.
-Adds new option to specify if the color transform should happen for YCC and what not.
