### PR TITLE
load through j.src setter as in original api

### DIFF
--- a/example.html
+++ b/example.html
@@ -17,7 +17,7 @@ function displayImage(canvasId, url) {
     j.copyToImageData(d);
     ctx.putImageData(d, 0, 0);
   };
-  j.load(url);
+  j.src = url;
 }
 
 function loadImages() {

--- a/jpg.js
+++ b/jpg.js
@@ -536,20 +536,6 @@ var JpegImage = (function jpegImage() {
   }
 
   constructor.prototype = {
-    load: function load(path) {
-      var xhr = new XMLHttpRequest();
-      xhr.open("GET", path, true);
-      xhr.responseType = "arraybuffer";
-      xhr.onload = (function() {
-        // TODO catch parse error
-        var data = new Uint8Array(xhr.response || xhr.mozResponseArrayBuffer);
-        this.parse(data);
-        if (this.onload)
-          this.onload();
-      }).bind(this);
-      xhr.send(null);
-    },
-
     parse: function parse(data) {
 
       function readUint16() {
@@ -960,6 +946,22 @@ var JpegImage = (function jpegImage() {
       }
     }
   };
+
+  Object.defineProperty(constructor.prototype, "src", {
+    set: function(path) {
+      var xhr = new XMLHttpRequest();
+      xhr.open('GET', path, true);
+      xhr.responseType = 'arraybuffer';
+      xhr.onload = (function() {
+        // TODO catch parse error
+        var data = new Uint8Array(xhr.response || xhr.mozResponseArrayBuffer);
+        this.parse(data);
+        if (this.onload)
+          this.onload();
+      }).bind(this);
+      xhr.send(null);
+    }
+  });
 
   return constructor;
 })();


### PR DESCRIPTION
Load through src setter

```
var foo = new Image();
foo.src = "j1.jpg";

var bar = new JpegImage();
bar.src = "j1.jpg";
```

Implemented with  https://developer.mozilla.org/ru/docs/JavaScript/Reference/Global_Objects/Object/defineProperty
