### PR TITLE
load through j.src implement with set operator

### DIFF
--- a/example.html
+++ b/example.html
@@ -17,7 +17,7 @@ function displayImage(canvasId, url) {
     j.copyToImageData(d);
     ctx.putImageData(d, 0, 0);
   };
-  j.load(url);
+  j.src = url;
 }
 
 function loadImages() {

--- a/jpg.js
+++ b/jpg.js
@@ -536,7 +536,7 @@ var JpegImage = (function jpegImage() {
   }
 
   constructor.prototype = {
-    load: function load(path) {
+    set src (path) {
       var xhr = new XMLHttpRequest();
       xhr.open("GET", path, true);
       xhr.responseType = "arraybuffer";


### PR DESCRIPTION
Closer to Image API

```
var foo = new Image();
foo.src = "j1.jpg";

var bar = new JpegImage();
bar.src = "j1.jpg";
```

Implemented with set operator https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/set
