### PR TITLE
Fix variable name passed to parse from load

### DIFF
--- a/jpg.js
+++ b/jpg.js
@@ -538,7 +538,7 @@ var JpegImage = (function jpegImage() {
   constructor.prototype = {
     load: function load(path) {
       var handleData = (function(data) {
-        this.parse(arr);
+        this.parse(data);
         if (this.onload)
           this.onload();
       }).bind(this);


### PR DESCRIPTION
Fixes the demo page. The bug was introduced by f9b04d7a887beb00ec4e2754c93ac250078cc676.
